### PR TITLE
Auslastung: Add icons for additional accessibility

### DIFF
--- a/src/client/Components/Abfahrt/Auslastung.jsx
+++ b/src/client/Components/Abfahrt/Auslastung.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import Tooltip from '@material-ui/core/Tooltip';
 import type { AppState } from 'AppState';
 import Done from '@material-ui/icons/Done';
-import Warning from '@material-ui/icons/Warning';
+import ErrorOutline from '@material-ui/icons/ErrorOutline';
 import Close from '@material-ui/icons/Close';
 import Help from '@material-ui/icons/Help';
 
@@ -46,7 +46,7 @@ function getIcon(auslastung) {
     case 0:
       return <Done />;
     case 1:
-      return <Warning />;
+      return <ErrorOutline />;
     case 2:
       return <Close />;
     default:

--- a/src/client/Components/Abfahrt/Auslastung.jsx
+++ b/src/client/Components/Abfahrt/Auslastung.jsx
@@ -4,14 +4,14 @@ import { type Abfahrt } from 'types/abfahrten';
 import { connect } from 'react-redux';
 import { getAuslastung } from 'client/actions/auslastung';
 import { getAuslastungForIdAndStation } from 'client/selector/auslastung';
+import Close from '@material-ui/icons/Close';
+import Done from '@material-ui/icons/Done';
+import ErrorOutline from '@material-ui/icons/ErrorOutline';
+import Help from '@material-ui/icons/Help';
 import Loading from '../Loading';
 import React from 'react';
 import Tooltip from '@material-ui/core/Tooltip';
 import type { AppState } from 'AppState';
-import Done from '@material-ui/icons/Done';
-import ErrorOutline from '@material-ui/icons/ErrorOutline';
-import Close from '@material-ui/icons/Close';
-import Help from '@material-ui/icons/Help';
 
 type StateProps = {|
   auslastung: ?{ first: 0 | 1 | 2, second: 0 | 1 | 2 },
@@ -84,17 +84,13 @@ class Auslastung extends React.PureComponent<Props> {
         <div className="Auslastung__entry">
           <span>1</span>
           <Tooltip title={getTooltipText(auslastung.first)}>
-            <span className={`Auslastung__icon A${auslastung.first}`}>
-              {getIcon(auslastung.first)}
-            </span>
+            <span className={`Auslastung__icon A${auslastung.first}`}>{getIcon(auslastung.first)}</span>
           </Tooltip>
         </div>
         <div className="Auslastung__entry">
           <span>2</span>
           <Tooltip title={getTooltipText(auslastung.second)}>
-            <span className={`Auslastung__icon A${auslastung.second}`}>
-              {getIcon(auslastung.second)}
-            </span>
+            <span className={`Auslastung__icon A${auslastung.second}`}>{getIcon(auslastung.second)}</span>
           </Tooltip>
         </div>
       </div>

--- a/src/client/Components/Abfahrt/Auslastung.jsx
+++ b/src/client/Components/Abfahrt/Auslastung.jsx
@@ -8,6 +8,10 @@ import Loading from '../Loading';
 import React from 'react';
 import Tooltip from '@material-ui/core/Tooltip';
 import type { AppState } from 'AppState';
+import Done from '@material-ui/icons/Done';
+import Warning from '@material-ui/icons/Warning';
+import Close from '@material-ui/icons/Close';
+import Help from '@material-ui/icons/Help';
 
 type StateProps = {|
   auslastung: ?{ first: 0 | 1 | 2, second: 0 | 1 | 2 },
@@ -34,6 +38,19 @@ function getTooltipText(auslastung) {
       return 'Zug stark ausgelastet';
     default:
       return 'Unbekannt';
+  }
+}
+
+function getIcon(auslastung) {
+  switch (auslastung) {
+    case 0:
+      return <Done />;
+    case 1:
+      return <Warning />;
+    case 2:
+      return <Close />;
+    default:
+      return <Help />;
   }
 }
 
@@ -67,13 +84,17 @@ class Auslastung extends React.PureComponent<Props> {
         <div className="Auslastung__entry">
           <span>1</span>
           <Tooltip title={getTooltipText(auslastung.first)}>
-            <span className={`Auslastung__icon A${auslastung.first}`} />
+            <span className={`Auslastung__icon A${auslastung.first}`}>
+              {getIcon(auslastung.first)}
+            </span>
           </Tooltip>
         </div>
         <div className="Auslastung__entry">
           <span>2</span>
           <Tooltip title={getTooltipText(auslastung.second)}>
-            <span className={`Auslastung__icon A${auslastung.second}`} />
+            <span className={`Auslastung__icon A${auslastung.second}`}>
+              {getIcon(auslastung.second)}
+            </span>
           </Tooltip>
         </div>
       </div>

--- a/src/client/Components/Abfahrt/Auslastung.scss
+++ b/src/client/Components/Abfahrt/Auslastung.scss
@@ -9,21 +9,24 @@
   }
 
   &__icon {
-    font-size: 70%;
-    height: 1.4em;
-    width: 1.4em;
+    font-size: 0.5em;
+    height: 1.6em;
+    width: 1.6em;
     display: inline-block;
     border-radius: 50%;
     text-align: center;
-    color: #fff;
+    padding: 0.2em;
     &.A0 {
       background-color: green;
+      color: #fff;
     }
     &.A1 {
       background-color: yellow;
+      color: black;
     }
     &.A2 {
       background-color: red;
+      color: #fff;
     }
   }
 }

--- a/src/client/Components/Abfahrt/Auslastung.scss
+++ b/src/client/Components/Abfahrt/Auslastung.scss
@@ -9,10 +9,13 @@
   }
 
   &__icon {
-    height: 0.7em;
-    width: 0.7em;
+    font-size: 70%;
+    height: 1.4em;
+    width: 1.4em;
     display: inline-block;
     border-radius: 50%;
+    text-align: center;
+    color: #fff;
     &.A0 {
       background-color: green;
     }


### PR DESCRIPTION
A tooltip is good, an icon is better. Help colorblind people to easier read the Auslastungen.