### PR TITLE
Add delay code 66 (flooded area)

### DIFF
--- a/src/server/Abfahrten/messageLookup.js
+++ b/src/server/Abfahrten/messageLookup.js
@@ -56,6 +56,7 @@ export default {
   '63': 'Technische Untersuchung am Zug',
   '64': 'Weichenstörung',
   '65': 'Erdrutsch',
+  '66': 'Hochwasser',
   '70': 'Kein WLAN',
   '71': 'WLAN in einzelnen Wagen nicht verfügbar',
   '73': 'Mehrzweckabteil vorne',


### PR DESCRIPTION
Delay code 66 seems to refer to flooded areas ("Hochwasser"). Currently frequently used around Hagen Hbf / RB 52.