### PR TITLE
IRIS-Nachricht 37: Störung am Wagen

### DIFF
--- a/src/server/Abfahrten/messageLookup.ts
+++ b/src/server/Abfahrten/messageLookup.ts
@@ -35,6 +35,7 @@ export default {
   '34': 'Signalstörung',
   '35': 'Streckensperrung',
   '36': 'Technische Störung am Zug',
+  '37': 'Technische Störung am Wagen', 
   '38': 'Technische Störung an der Strecke',
   '39': 'Anhängen von zusätzlichen Wagen',
   '40': 'Stellwerksstörung/-ausfall',


### PR DESCRIPTION
Laut https://github.com/derf/Travel-Status-DE-IRIS, dem Repository aus dem die IRIS-Fehlermeldungen stammen, steht Fehler / Nachricht 37 für "Technische Störung am Wagen": https://github.com/derf/Travel-Status-DE-IRIS/commit/08c27ae4f121942b0da5e9a44c6256423587857c