### PR TITLE
consider using OpenStreetMap for foot routing

### DIFF
--- a/src/client/Routing/Components/RouteList/SegmentTrainComponent/WalkSegmentTrain.tsx
+++ b/src/client/Routing/Components/RouteList/SegmentTrainComponent/WalkSegmentTrain.tsx
@@ -12,7 +12,7 @@ interface Props {
 const WalkSegmentTrain = ({ segment, className }: Props) => {
   const classes = useStyles();
 
-  const mapsLink = `https://www.google.com/maps/dir/?api=1&origin=${segment.segmentStart.coordinates.lat},${segment.segmentStart.coordinates.lng}&destination=${segment.segmentDestination.coordinates.lat},${segment.segmentDestination.coordinates.lng}&travelmode=walking`;
+  const mapsLink = `https://www.openstreetmap.org/directions?engine=graphhopper_foot&route=${segment.segmentStart.coordinates.lat}%2C${segment.segmentStart.coordinates.lng}%3B${segment.segmentDestination.coordinates.lat}%2C${segment.segmentDestination.coordinates.lng}`;
 
   return (
     <div className={className}>


### PR DESCRIPTION
This swtiches the "Maps Routing" link for _"Fußweg"_ sections of a route to use [OpenStreetMap](https://www.openstreetmap.org/about) instead of Google Maps. This has several benefits: OSM is a free and open project and can be improved by everyone. OSM often offers better pedestrian routing results, especially in well mapped countries like Germany. Large rail stations are often well mapped in OSM, including individual platforms, underpasses,  internal passages and corridors.