### PR TITLE
Add ICE4 TZ names

### DIFF
--- a/src/server/Reihung/ICENaming.ts
+++ b/src/server/Reihung/ICENaming.ts
@@ -226,6 +226,10 @@ const naming = {
   218: 'Braunschweig',
   1112: 'Freie und Hansestadt Hamburg',
   4610: 'Frankfurt am Main',
+  9006: 'Martin Luther',
+  9018: 'Freistaat Bayern',
+  9025: 'Nordrhein-Westfalen',
+  9026: 'Zürichsee',
 };
 
 export default (tzn?: string): string | undefined => {


### PR DESCRIPTION
A few (currently 4) ICE4 trains are also named.

Source: https://de.wikipedia.org/wiki/Liste_nach_Gemeinden_und_Regionen_benannter_IC/ICE-Fahrzeuge#ICE-4-Triebz%C3%BCge