### PR TITLE
Add ICE4 train name 'Baden-Württemberg' (Tz9041)

### DIFF
--- a/src/server/Reihung/ICENaming.ts
+++ b/src/server/Reihung/ICENaming.ts
@@ -230,6 +230,7 @@ const naming = {
   9018: 'Freistaat Bayern',
   9025: 'Nordrhein-Westfalen',
   9026: 'Zürichsee',
+  9041: 'Baden-Württemberg',
   152: 'Hanau',
   166: 'Gelnhausen',
 };


### PR DESCRIPTION
Seit gestern heißt Tz9041 'Baden-Württemberg'.

Quelle:
https://www.deutschebahn.com/pr-stuttgart-de/aktuell/presseinformationen/001-pm_ice_vier_botschafter_baden_wuerttemberg-4744780
Auf dem Pressefoto unten ist die Fahrzeugnummer zu sehen (0812 **041**-3)