### PR TITLE
fix berlin Hbf/Hauptbahnhof

### DIFF
--- a/src/client/Abfahrten/Components/MostUsed.tsx
+++ b/src/client/Abfahrten/Components/MostUsed.tsx
@@ -7,7 +7,7 @@ const mostUsed = [
   { title: 'Hannover Hbf', id: '8000152' },
   { title: 'Hamburg Hbf', id: '8002549' },
   { title: 'Mannheim Hbf', id: '8000244' },
-  { title: 'Berlin Hauptbahnhof', id: '8011160' },
+  { title: 'Berlin Hbf', id: '8011160' },
   { title: 'Stuttgart Hbf', id: '8000096' },
   { title: 'Düsseldorf Hbf', id: '8000085' },
   { title: 'Köln Hbf', id: '8000207' },


### PR DESCRIPTION
fixes #214 

Most APIs know Berlin Hauptbahnhof. The current default only Berlin Hbf.
Berlin Hauptbahnhof does not resolve to Berlin Hbf. Berlin Hbf does resolve to Berlin Hauptbahnhof for APIs where it's called Berlin Hauptbahnhof.