### PR TITLE
Update ICENaming.ts

### DIFF
--- a/src/server/Reihung/ICENaming.ts
+++ b/src/server/Reihung/ICENaming.ts
@@ -3,6 +3,7 @@
 const naming = {
   4712: 'Dillingen a.d. Donau',
   4601: 'Europa/Europe',
+  4602: 'Euregio Maas-Rhein',
   1183: 'Oberursel (Taunus)',
   363: 'Weilheim i. OB',
   187: 'Mühldorf a. Inn',


### PR DESCRIPTION
4602: 'Euregio Maas-Rhein'

Sources:
https://www.deutschebahn.com/pr-duesseldorf-de/aktuell/presseinformationen/ICE-auf-den-Namen-Euregio-Maas-Rhein-getauft-4937940
https://de.wikipedia.org/wiki/Liste_nach_Gemeinden_und_Regionen_benannter_IC/ICE-Fahrzeuge