### PR TITLE
feat: show opeartor on details page

### DIFF
--- a/src/client/Common/Components/Details/Header.style.ts
+++ b/src/client/Common/Components/Details/Header.style.ts
@@ -1,15 +1,29 @@
+import { CSSProperties } from '@material-ui/core/styles/withStyles';
 import { makeStyles } from '@material-ui/styles';
+
+const singleLine: CSSProperties = {
+  overflow: 'hidden',
+  maxWidth: '100%',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
 
 export default makeStyles({
   product: {
     gridArea: 'p',
+    ...singleLine,
   },
   date: {
     gridArea: 'd',
+    ...singleLine,
   },
   arrow: {
     gridArea: 'a',
     minWidth: '1.5em',
+  },
+  operator: {
+    gridArea: 'o',
+    ...singleLine,
   },
   destination: {
     gridArea: 'g',
@@ -18,8 +32,8 @@ export default makeStyles({
     width: '100%',
     display: 'grid',
     gridTemplateColumns: '1fr min-content 1fr',
-    gridTemplateRows: '1fr 1fr',
-    gridTemplateAreas: '"p a g" "d a g"',
+    gridTemplateRows: '1fr 1fr 1fr',
+    gridTemplateAreas: '"p a g" "o a g" "d a g"',
     alignItems: 'center',
     justifyItems: 'center',
   },

--- a/src/client/Common/Components/Details/Header.tsx
+++ b/src/client/Common/Components/Details/Header.tsx
@@ -1,4 +1,5 @@
 import { format } from 'date-fns';
+import { Tooltip } from '@material-ui/core';
 import BaseHeader from '../BaseHeader';
 import DetailsContext from './DetailsContext';
 import PlannedType from 'Common/Components/PlannedType';
@@ -25,6 +26,13 @@ const Header = ({ train }: Props) => {
         </span>
         {details && (
           <>
+            {details.train.operator && (
+              <Tooltip title={details.train.operator.name}>
+                <span className={classes.operator}>
+                  {details.train.operator.name}
+                </span>
+              </Tooltip>
+            )}
             <span className={classes.date}>
               {format(details.departure.time, 'dd.MM.yyyy')}
             </span>

--- a/src/client/Routing/Components/RouteList/SegmentTrainComponent/JnySegmentTrain.tsx
+++ b/src/client/Routing/Components/RouteList/SegmentTrainComponent/JnySegmentTrain.tsx
@@ -26,10 +26,12 @@ const JnySegmentTrain = ({
     <div onClick={onTrainClick} className={className}>
       <div className={classes.trainInfo}>
         <span className={classes.trainMargin}>
-          {segment.train.name}{' '}
-          {segment.plannedSequence && (
-            <PlannedType plannedSequence={segment.plannedSequence} />
-          )}
+          <span>
+            {segment.train.name}{' '}
+            {segment.plannedSequence && (
+              <PlannedType plannedSequence={segment.plannedSequence} />
+            )}
+          </span>
         </span>
         <span className={cc(classes.trainMargin, classes.destination)}>
           {segment.finalDestination}

--- a/src/client/Routing/Components/RouteList/SegmentTrainComponent/style.ts
+++ b/src/client/Routing/Components/RouteList/SegmentTrainComponent/style.ts
@@ -8,11 +8,11 @@ export default makeStyles({
   trainMargin: {
     flex: 0.7,
     marginRight: '.5em',
+    display: 'flex',
+    flexDirection: 'column',
   },
   destination: {
     flex: 1,
-    display: 'flex',
-    flexDirection: 'column',
   },
   reihung: {
     fontSize: '0.5em',


### PR DESCRIPTION
fixes #60 

Operator on departure board is not included. I do not have the information there.
In Routes also omitted. Already to much going on on that page - would make it less usefull.
It's something people rarely need => details page is enough.