### PR TITLE
Add enocdeURIComponent() to HAFAS station search

### DIFF
--- a/cypress/fixtures/regional/departureArndtSpittastrasse.json
+++ b/cypress/fixtures/regional/departureArndtSpittastrasse.json
@@ -1,0 +1,8454 @@
+{
+  "lookbehind": [],
+  "departures": [
+    {
+      "initialDeparture": "2021-03-04T20:21:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:21:00.000Z",
+        "time": "2021-03-04T20:21:00.000Z",
+        "delay": 0
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:21:00.000Z",
+        "time": "2021-03-04T20:21:00.000Z",
+        "delay": 0
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|1|80|403202177629",
+      "rawId": "1|1178274|1|80|403202177629",
+      "mediumId": "1|1178274|1|80|403202177629",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "77629",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:21:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:20:00.000Z",
+        "time": "2021-03-04T20:20:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:21:00.000Z",
+        "time": "2021-03-04T20:21:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|2|80|403202179218",
+      "rawId": "1|1178487|2|80|403202179218",
+      "mediumId": "1|1178487|2|80|403202179218",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "79218",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:27:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:27:00.000Z",
+        "time": "2021-03-04T20:27:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:27:00.000Z",
+        "time": "2021-03-04T20:27:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|3|80|403202178694",
+      "rawId": "1|1178069|3|80|403202178694",
+      "mediumId": "1|1178069|3|80|403202178694",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "78694",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:27:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:26:00.000Z",
+        "time": "2021-03-04T20:27:00.000Z",
+        "delay": 1
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:27:00.000Z",
+        "time": "2021-03-04T20:27:00.000Z",
+        "delay": 0
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "scheduledDestination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "id": "1|1178310|3|80|403202179442",
+      "rawId": "1|1178310|3|80|403202179442",
+      "mediumId": "1|1178310|3|80|403202179442",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart",
+          "showVia": true
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "79442",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:29:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:29:00.000Z",
+        "time": "2021-03-04T20:29:00.000Z",
+        "delay": 0
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:29:00.000Z",
+        "time": "2021-03-04T20:30:00.000Z",
+        "delay": 1
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178514|2|80|403202179319",
+      "rawId": "1|1178514|2|80|403202179319",
+      "mediumId": "1|1178514|2|80|403202179319",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "79319",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:33:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:32:00.000Z",
+        "time": "2021-03-04T20:33:00.000Z",
+        "delay": 1
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:33:00.000Z",
+        "time": "2021-03-04T20:33:00.000Z",
+        "delay": 0
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Neugereut, Stuttgart",
+      "scheduledDestination": "Neugereut, Stuttgart",
+      "id": "1|1178313|3|80|403202179451",
+      "rawId": "1|1178313|3|80|403202179451",
+      "mediumId": "1|1178313|3|80|403202179451",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Botnang, Stuttgart"
+        },
+        {
+          "name": "Eltinger Straße, Stuttgart"
+        },
+        {
+          "name": "Millöckerstraße, Stuttgart"
+        },
+        {
+          "name": "Beethovenstraße, Stuttgart"
+        },
+        {
+          "name": "Lindpaintnerstraße, Stuttgart"
+        },
+        {
+          "name": "Herderplatz, Stuttgart"
+        },
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Neugereut, Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "79451",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:36:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:36:00.000Z",
+        "time": "2021-03-04T20:37:00.000Z",
+        "delay": 1
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:36:00.000Z",
+        "time": "2021-03-04T20:37:00.000Z",
+        "delay": 1
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|2|80|403202178484",
+      "rawId": "1|1178274|2|80|403202178484",
+      "mediumId": "1|1178274|2|80|403202178484",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "78484",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:36:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:35:00.000Z",
+        "time": "2021-03-04T20:35:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:36:00.000Z",
+        "time": "2021-03-04T20:36:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|3|80|403202179978",
+      "rawId": "1|1178487|3|80|403202179978",
+      "mediumId": "1|1178487|3|80|403202179978",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "79978",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:42:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:42:00.000Z",
+        "time": "2021-03-04T20:42:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:42:00.000Z",
+        "time": "2021-03-04T20:42:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|4|80|403202179487",
+      "rawId": "1|1178069|4|80|403202179487",
+      "mediumId": "1|1178069|4|80|403202179487",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "79487",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:42:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:41:00.000Z",
+        "time": "2021-03-04T20:42:00.000Z",
+        "delay": 1
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:42:00.000Z",
+        "time": "2021-03-04T20:42:00.000Z",
+        "delay": 0
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "scheduledDestination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "id": "1|1178310|4|80|403202180270",
+      "rawId": "1|1178310|4|80|403202180270",
+      "mediumId": "1|1178310|4|80|403202180270",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart",
+          "showVia": true
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "80270",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:44:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:44:00.000Z",
+        "time": "2021-03-04T20:44:00.000Z",
+        "delay": 0
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:44:00.000Z",
+        "time": "2021-03-04T20:45:00.000Z",
+        "delay": 1
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178514|3|80|403202180118",
+      "rawId": "1|1178514|3|80|403202180118",
+      "mediumId": "1|1178514|3|80|403202180118",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "80118",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:48:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:47:00.000Z",
+        "time": "2021-03-04T20:48:00.000Z",
+        "delay": 1
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:48:00.000Z",
+        "time": "2021-03-04T20:48:00.000Z",
+        "delay": 0
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Neugereut, Stuttgart",
+      "scheduledDestination": "Neugereut, Stuttgart",
+      "id": "1|1178313|4|80|403202180283",
+      "rawId": "1|1178313|4|80|403202180283",
+      "mediumId": "1|1178313|4|80|403202180283",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Botnang, Stuttgart"
+        },
+        {
+          "name": "Eltinger Straße, Stuttgart"
+        },
+        {
+          "name": "Millöckerstraße, Stuttgart"
+        },
+        {
+          "name": "Beethovenstraße, Stuttgart"
+        },
+        {
+          "name": "Lindpaintnerstraße, Stuttgart"
+        },
+        {
+          "name": "Herderplatz, Stuttgart"
+        },
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Neugereut, Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "80283",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:51:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:51:00.000Z",
+        "time": "2021-03-04T20:51:00.000Z",
+        "delay": 0
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:51:00.000Z",
+        "time": "2021-03-04T20:52:00.000Z",
+        "delay": 1
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|3|80|403202179290",
+      "rawId": "1|1178274|3|80|403202179290",
+      "mediumId": "1|1178274|3|80|403202179290",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "79290",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:51:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:50:00.000Z",
+        "time": "2021-03-04T20:50:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:51:00.000Z",
+        "time": "2021-03-04T20:51:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|4|80|403202180845",
+      "rawId": "1|1178487|4|80|403202180845",
+      "mediumId": "1|1178487|4|80|403202180845",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "80845",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:57:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:57:00.000Z",
+        "time": "2021-03-04T20:57:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:57:00.000Z",
+        "time": "2021-03-04T20:57:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|5|80|403202180334",
+      "rawId": "1|1178069|5|80|403202180334",
+      "mediumId": "1|1178069|5|80|403202180334",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "80334",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:57:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:56:00.000Z",
+        "time": "2021-03-04T20:57:00.000Z",
+        "delay": 1
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:57:00.000Z",
+        "time": "2021-03-04T20:57:00.000Z",
+        "delay": 0
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "scheduledDestination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "id": "1|1178310|5|80|403202181084",
+      "rawId": "1|1178310|5|80|403202181084",
+      "mediumId": "1|1178310|5|80|403202181084",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart",
+          "showVia": true
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "81084",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T20:59:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T20:59:00.000Z",
+        "time": "2021-03-04T20:59:00.000Z",
+        "delay": 0
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T20:59:00.000Z",
+        "time": "2021-03-04T21:00:00.000Z",
+        "delay": 1
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178514|4|80|403202180969",
+      "rawId": "1|1178514|4|80|403202180969",
+      "mediumId": "1|1178514|4|80|403202180969",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "80969",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:03:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:02:00.000Z",
+        "time": "2021-03-04T21:03:00.000Z",
+        "delay": 1
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:03:00.000Z",
+        "time": "2021-03-04T21:03:00.000Z",
+        "delay": 0
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Neugereut, Stuttgart",
+      "scheduledDestination": "Neugereut, Stuttgart",
+      "id": "1|1178313|5|80|403202181096",
+      "rawId": "1|1178313|5|80|403202181096",
+      "mediumId": "1|1178313|5|80|403202181096",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Botnang, Stuttgart"
+        },
+        {
+          "name": "Eltinger Straße, Stuttgart"
+        },
+        {
+          "name": "Millöckerstraße, Stuttgart"
+        },
+        {
+          "name": "Beethovenstraße, Stuttgart"
+        },
+        {
+          "name": "Lindpaintnerstraße, Stuttgart"
+        },
+        {
+          "name": "Herderplatz, Stuttgart"
+        },
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Neugereut, Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "81096",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:06:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:06:00.000Z",
+        "time": "2021-03-04T21:06:00.000Z",
+        "delay": 0
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:06:00.000Z",
+        "time": "2021-03-04T21:07:00.000Z",
+        "delay": 1
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|4|80|403202180069",
+      "rawId": "1|1178274|4|80|403202180069",
+      "mediumId": "1|1178274|4|80|403202180069",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "80069",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:06:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:05:00.000Z",
+        "time": "2021-03-04T21:05:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:06:00.000Z",
+        "time": "2021-03-04T21:06:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|5|80|403202181595",
+      "rawId": "1|1178487|5|80|403202181595",
+      "mediumId": "1|1178487|5|80|403202181595",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "81595",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:12:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:12:00.000Z",
+        "time": "2021-03-04T21:12:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:12:00.000Z",
+        "time": "2021-03-04T21:12:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|6|80|403202181139",
+      "rawId": "1|1178069|6|80|403202181139",
+      "mediumId": "1|1178069|6|80|403202181139",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "81139",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:12:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:11:00.000Z",
+        "time": "2021-03-04T21:12:00.000Z",
+        "delay": 1
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:12:00.000Z",
+        "time": "2021-03-04T21:12:00.000Z",
+        "delay": 0
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "scheduledDestination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "id": "1|1178310|6|80|403202181833",
+      "rawId": "1|1178310|6|80|403202181833",
+      "mediumId": "1|1178310|6|80|403202181833",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart",
+          "showVia": true
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "81833",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:14:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:14:00.000Z",
+        "time": "2021-03-04T21:14:00.000Z",
+        "delay": 0
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:14:00.000Z",
+        "time": "2021-03-04T21:15:00.000Z",
+        "delay": 1
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178514|5|80|403202181716",
+      "rawId": "1|1178514|5|80|403202181716",
+      "mediumId": "1|1178514|5|80|403202181716",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "81716",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:18:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:17:00.000Z",
+        "time": "2021-03-04T21:18:00.000Z",
+        "delay": 1
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:18:00.000Z",
+        "time": "2021-03-04T21:18:00.000Z",
+        "delay": 0
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Neugereut, Stuttgart",
+      "scheduledDestination": "Neugereut, Stuttgart",
+      "id": "1|1178313|6|80|403202181844",
+      "rawId": "1|1178313|6|80|403202181844",
+      "mediumId": "1|1178313|6|80|403202181844",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Botnang, Stuttgart"
+        },
+        {
+          "name": "Eltinger Straße, Stuttgart"
+        },
+        {
+          "name": "Millöckerstraße, Stuttgart"
+        },
+        {
+          "name": "Beethovenstraße, Stuttgart"
+        },
+        {
+          "name": "Lindpaintnerstraße, Stuttgart"
+        },
+        {
+          "name": "Herderplatz, Stuttgart"
+        },
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Neugereut, Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "81844",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:21:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:21:00.000Z",
+        "time": "2021-03-04T21:21:00.000Z",
+        "delay": 0
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:21:00.000Z",
+        "time": "2021-03-04T21:22:00.000Z",
+        "delay": 1
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|5|80|403202180931",
+      "rawId": "1|1178274|5|80|403202180931",
+      "mediumId": "1|1178274|5|80|403202180931",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "80931",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:21:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:20:00.000Z",
+        "time": "2021-03-04T21:20:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:21:00.000Z",
+        "time": "2021-03-04T21:21:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|6|80|403202182381",
+      "rawId": "1|1178487|6|80|403202182381",
+      "mediumId": "1|1178487|6|80|403202182381",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "82381",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:27:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:27:00.000Z",
+        "time": "2021-03-04T21:27:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:27:00.000Z",
+        "time": "2021-03-04T21:27:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|7|80|403202181889",
+      "rawId": "1|1178069|7|80|403202181889",
+      "mediumId": "1|1178069|7|80|403202181889",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "81889",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:27:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:26:00.000Z",
+        "time": "2021-03-04T21:26:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:27:00.000Z",
+        "time": "2021-03-04T21:27:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "scheduledDestination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "id": "1|1178310|7|80|403202182596",
+      "rawId": "1|1178310|7|80|403202182596",
+      "mediumId": "1|1178310|7|80|403202182596",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart",
+          "showVia": true
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "82596",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:29:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:29:00.000Z",
+        "time": "2021-03-04T21:29:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:29:00.000Z",
+        "time": "2021-03-04T21:29:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178514|6|80|403202182494",
+      "rawId": "1|1178514|6|80|403202182494",
+      "mediumId": "1|1178514|6|80|403202182494",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "82494",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:33:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:32:00.000Z",
+        "time": "2021-03-04T21:32:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:33:00.000Z",
+        "time": "2021-03-04T21:33:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Neugereut, Stuttgart",
+      "scheduledDestination": "Neugereut, Stuttgart",
+      "id": "1|1178313|7|80|403202182605",
+      "rawId": "1|1178313|7|80|403202182605",
+      "mediumId": "1|1178313|7|80|403202182605",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Botnang, Stuttgart"
+        },
+        {
+          "name": "Eltinger Straße, Stuttgart"
+        },
+        {
+          "name": "Millöckerstraße, Stuttgart"
+        },
+        {
+          "name": "Beethovenstraße, Stuttgart"
+        },
+        {
+          "name": "Lindpaintnerstraße, Stuttgart"
+        },
+        {
+          "name": "Herderplatz, Stuttgart"
+        },
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Neugereut, Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "82605",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:36:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:36:00.000Z",
+        "time": "2021-03-04T21:36:00.000Z",
+        "delay": 0
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:36:00.000Z",
+        "time": "2021-03-04T21:37:00.000Z",
+        "delay": 1
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|6|80|403202181683",
+      "rawId": "1|1178274|6|80|403202181683",
+      "mediumId": "1|1178274|6|80|403202181683",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "81683",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:36:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:35:00.000Z",
+        "time": "2021-03-04T21:35:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:36:00.000Z",
+        "time": "2021-03-04T21:36:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|7|80|403202183126",
+      "rawId": "1|1178487|7|80|403202183126",
+      "mediumId": "1|1178487|7|80|403202183126",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "83126",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:42:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:42:00.000Z",
+        "time": "2021-03-04T21:42:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:42:00.000Z",
+        "time": "2021-03-04T21:42:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|8|80|403202182632",
+      "rawId": "1|1178069|8|80|403202182632",
+      "mediumId": "1|1178069|8|80|403202182632",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "82632",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:42:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:41:00.000Z",
+        "time": "2021-03-04T21:41:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:42:00.000Z",
+        "time": "2021-03-04T21:42:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "scheduledDestination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "id": "1|1178310|8|80|403202183406",
+      "rawId": "1|1178310|8|80|403202183406",
+      "mediumId": "1|1178310|8|80|403202183406",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart",
+          "showVia": true
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "83406",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:44:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:44:00.000Z",
+        "time": "2021-03-04T21:44:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:44:00.000Z",
+        "time": "2021-03-04T21:44:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178514|7|80|403202183258",
+      "rawId": "1|1178514|7|80|403202183258",
+      "mediumId": "1|1178514|7|80|403202183258",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "83258",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:48:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:47:00.000Z",
+        "time": "2021-03-04T21:47:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:48:00.000Z",
+        "time": "2021-03-04T21:48:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Neugereut, Stuttgart",
+      "scheduledDestination": "Neugereut, Stuttgart",
+      "id": "1|1178313|8|80|403202183419",
+      "rawId": "1|1178313|8|80|403202183419",
+      "mediumId": "1|1178313|8|80|403202183419",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Botnang, Stuttgart"
+        },
+        {
+          "name": "Eltinger Straße, Stuttgart"
+        },
+        {
+          "name": "Millöckerstraße, Stuttgart"
+        },
+        {
+          "name": "Beethovenstraße, Stuttgart"
+        },
+        {
+          "name": "Lindpaintnerstraße, Stuttgart"
+        },
+        {
+          "name": "Herderplatz, Stuttgart"
+        },
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Neugereut, Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "83419",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:51:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:51:00.000Z",
+        "time": "2021-03-04T21:51:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:51:00.000Z",
+        "time": "2021-03-04T21:51:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|7|80|403202182457",
+      "rawId": "1|1178274|7|80|403202182457",
+      "mediumId": "1|1178274|7|80|403202182457",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "82457",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:51:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:50:00.000Z",
+        "time": "2021-03-04T21:50:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:51:00.000Z",
+        "time": "2021-03-04T21:51:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|8|80|403202183962",
+      "rawId": "1|1178487|8|80|403202183962",
+      "mediumId": "1|1178487|8|80|403202183962",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "83962",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:57:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:57:00.000Z",
+        "time": "2021-03-04T21:57:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:57:00.000Z",
+        "time": "2021-03-04T21:57:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|9|80|403202183468",
+      "rawId": "1|1178069|9|80|403202183468",
+      "mediumId": "1|1178069|9|80|403202183468",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "83468",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:57:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:56:00.000Z",
+        "time": "2021-03-04T21:56:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:57:00.000Z",
+        "time": "2021-03-04T21:57:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "scheduledDestination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "id": "1|1178310|9|80|403202184182",
+      "rawId": "1|1178310|9|80|403202184182",
+      "mediumId": "1|1178310|9|80|403202184182",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart",
+          "showVia": true
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "84182",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T21:59:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T21:59:00.000Z",
+        "time": "2021-03-04T21:59:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T21:59:00.000Z",
+        "time": "2021-03-04T21:59:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178514|8|80|403202184073",
+      "rawId": "1|1178514|8|80|403202184073",
+      "mediumId": "1|1178514|8|80|403202184073",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "84073",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:03:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:02:00.000Z",
+        "time": "2021-03-04T22:02:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:03:00.000Z",
+        "time": "2021-03-04T22:03:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Neugereut, Stuttgart",
+      "scheduledDestination": "Neugereut, Stuttgart",
+      "id": "1|1178313|9|80|403202184194",
+      "rawId": "1|1178313|9|80|403202184194",
+      "mediumId": "1|1178313|9|80|403202184194",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Botnang, Stuttgart"
+        },
+        {
+          "name": "Eltinger Straße, Stuttgart"
+        },
+        {
+          "name": "Millöckerstraße, Stuttgart"
+        },
+        {
+          "name": "Beethovenstraße, Stuttgart"
+        },
+        {
+          "name": "Lindpaintnerstraße, Stuttgart"
+        },
+        {
+          "name": "Herderplatz, Stuttgart"
+        },
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Neugereut, Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "84194",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:06:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:06:00.000Z",
+        "time": "2021-03-04T22:06:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:06:00.000Z",
+        "time": "2021-03-04T22:06:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|8|80|403202183213",
+      "rawId": "1|1178274|8|80|403202183213",
+      "mediumId": "1|1178274|8|80|403202183213",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "83213",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:06:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:05:00.000Z",
+        "time": "2021-03-04T22:05:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:06:00.000Z",
+        "time": "2021-03-04T22:06:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|9|80|403202184681",
+      "rawId": "1|1178487|9|80|403202184681",
+      "mediumId": "1|1178487|9|80|403202184681",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "84681",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:12:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:12:00.000Z",
+        "time": "2021-03-04T22:12:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:12:00.000Z",
+        "time": "2021-03-04T22:12:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|10|80|403202184234",
+      "rawId": "1|1178069|10|80|403202184234",
+      "mediumId": "1|1178069|10|80|403202184234",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "84234",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:12:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:11:00.000Z",
+        "time": "2021-03-04T22:11:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:12:00.000Z",
+        "time": "2021-03-04T22:12:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "scheduledDestination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "id": "1|1178310|10|80|403202184903",
+      "rawId": "1|1178310|10|80|403202184903",
+      "mediumId": "1|1178310|10|80|403202184903",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart",
+          "showVia": true
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "84903",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:14:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:14:00.000Z",
+        "time": "2021-03-04T22:14:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:14:00.000Z",
+        "time": "2021-03-04T22:14:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178514|9|80|403202184799",
+      "rawId": "1|1178514|9|80|403202184799",
+      "mediumId": "1|1178514|9|80|403202184799",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "84799",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:18:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:17:00.000Z",
+        "time": "2021-03-04T22:17:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:18:00.000Z",
+        "time": "2021-03-04T22:18:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Neugereut, Stuttgart",
+      "scheduledDestination": "Neugereut, Stuttgart",
+      "id": "1|1178313|10|80|403202184912",
+      "rawId": "1|1178313|10|80|403202184912",
+      "mediumId": "1|1178313|10|80|403202184912",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Botnang, Stuttgart"
+        },
+        {
+          "name": "Eltinger Straße, Stuttgart"
+        },
+        {
+          "name": "Millöckerstraße, Stuttgart"
+        },
+        {
+          "name": "Beethovenstraße, Stuttgart"
+        },
+        {
+          "name": "Lindpaintnerstraße, Stuttgart"
+        },
+        {
+          "name": "Herderplatz, Stuttgart"
+        },
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Neugereut, Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "84912",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:21:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:21:00.000Z",
+        "time": "2021-03-04T22:21:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:21:00.000Z",
+        "time": "2021-03-04T22:21:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|9|80|403202184030",
+      "rawId": "1|1178274|9|80|403202184030",
+      "mediumId": "1|1178274|9|80|403202184030",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "84030",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:21:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:20:00.000Z",
+        "time": "2021-03-04T22:20:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:21:00.000Z",
+        "time": "2021-03-04T22:21:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|10|80|403202185396",
+      "rawId": "1|1178487|10|80|403202185396",
+      "mediumId": "1|1178487|10|80|403202185396",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "85396",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:27:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:27:00.000Z",
+        "time": "2021-03-04T22:27:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:27:00.000Z",
+        "time": "2021-03-04T22:27:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|11|80|403202184949",
+      "rawId": "1|1178069|11|80|403202184949",
+      "mediumId": "1|1178069|11|80|403202184949",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "84949",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:27:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:26:00.000Z",
+        "time": "2021-03-04T22:26:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:27:00.000Z",
+        "time": "2021-03-04T22:27:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "scheduledDestination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "id": "1|1178310|11|80|403202185596",
+      "rawId": "1|1178310|11|80|403202185596",
+      "mediumId": "1|1178310|11|80|403202185596",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart",
+          "showVia": true
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "85596",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:29:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:29:00.000Z",
+        "time": "2021-03-04T22:29:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:29:00.000Z",
+        "time": "2021-03-04T22:29:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178514|10|80|403202185492",
+      "rawId": "1|1178514|10|80|403202185492",
+      "mediumId": "1|1178514|10|80|403202185492",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "85492",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:33:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:32:00.000Z",
+        "time": "2021-03-04T22:32:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:33:00.000Z",
+        "time": "2021-03-04T22:33:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Neugereut, Stuttgart",
+      "scheduledDestination": "Neugereut, Stuttgart",
+      "id": "1|1178313|11|80|403202185605",
+      "rawId": "1|1178313|11|80|403202185605",
+      "mediumId": "1|1178313|11|80|403202185605",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Botnang, Stuttgart"
+        },
+        {
+          "name": "Eltinger Straße, Stuttgart"
+        },
+        {
+          "name": "Millöckerstraße, Stuttgart"
+        },
+        {
+          "name": "Beethovenstraße, Stuttgart"
+        },
+        {
+          "name": "Lindpaintnerstraße, Stuttgart"
+        },
+        {
+          "name": "Herderplatz, Stuttgart"
+        },
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Neugereut, Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "85605",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:36:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:36:00.000Z",
+        "time": "2021-03-04T22:36:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:36:00.000Z",
+        "time": "2021-03-04T22:36:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|10|80|403202184767",
+      "rawId": "1|1178274|10|80|403202184767",
+      "mediumId": "1|1178274|10|80|403202184767",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "84767",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:36:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:35:00.000Z",
+        "time": "2021-03-04T22:35:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:36:00.000Z",
+        "time": "2021-03-04T22:36:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|11|80|403202186074",
+      "rawId": "1|1178487|11|80|403202186074",
+      "mediumId": "1|1178487|11|80|403202186074",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "86074",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:42:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:42:00.000Z",
+        "time": "2021-03-04T22:42:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:42:00.000Z",
+        "time": "2021-03-04T22:42:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|12|80|403202185632",
+      "rawId": "1|1178069|12|80|403202185632",
+      "mediumId": "1|1178069|12|80|403202185632",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "85632",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:42:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:41:00.000Z",
+        "time": "2021-03-04T22:41:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:42:00.000Z",
+        "time": "2021-03-04T22:42:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "scheduledDestination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "id": "1|1178310|12|80|403202186316",
+      "rawId": "1|1178310|12|80|403202186316",
+      "mediumId": "1|1178310|12|80|403202186316",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart",
+          "showVia": true
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "86316",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:44:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:44:00.000Z",
+        "time": "2021-03-04T22:44:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:44:00.000Z",
+        "time": "2021-03-04T22:44:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178514|11|80|403202186192",
+      "rawId": "1|1178514|11|80|403202186192",
+      "mediumId": "1|1178514|11|80|403202186192",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "86192",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:48:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:47:00.000Z",
+        "time": "2021-03-04T22:47:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:48:00.000Z",
+        "time": "2021-03-04T22:48:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Neugereut, Stuttgart",
+      "scheduledDestination": "Neugereut, Stuttgart",
+      "id": "1|1178313|12|80|403202186332",
+      "rawId": "1|1178313|12|80|403202186332",
+      "mediumId": "1|1178313|12|80|403202186332",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Botnang, Stuttgart"
+        },
+        {
+          "name": "Eltinger Straße, Stuttgart"
+        },
+        {
+          "name": "Millöckerstraße, Stuttgart"
+        },
+        {
+          "name": "Beethovenstraße, Stuttgart"
+        },
+        {
+          "name": "Lindpaintnerstraße, Stuttgart"
+        },
+        {
+          "name": "Herderplatz, Stuttgart"
+        },
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Neugereut, Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "86332",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:51:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:51:00.000Z",
+        "time": "2021-03-04T22:51:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:51:00.000Z",
+        "time": "2021-03-04T22:51:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|11|80|403202185456",
+      "rawId": "1|1178274|11|80|403202185456",
+      "mediumId": "1|1178274|11|80|403202185456",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "85456",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:51:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:50:00.000Z",
+        "time": "2021-03-04T22:50:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:51:00.000Z",
+        "time": "2021-03-04T22:51:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|12|80|403202186773",
+      "rawId": "1|1178487|12|80|403202186773",
+      "mediumId": "1|1178487|12|80|403202186773",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "86773",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:57:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:57:00.000Z",
+        "time": "2021-03-04T22:57:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:57:00.000Z",
+        "time": "2021-03-04T22:57:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|13|80|403202186371",
+      "rawId": "1|1178069|13|80|403202186371",
+      "mediumId": "1|1178069|13|80|403202186371",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "86371",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:57:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:56:00.000Z",
+        "time": "2021-03-04T22:56:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:57:00.000Z",
+        "time": "2021-03-04T22:57:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "scheduledDestination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "id": "1|1178310|13|80|403202186962",
+      "rawId": "1|1178310|13|80|403202186962",
+      "mediumId": "1|1178310|13|80|403202186962",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart",
+          "showVia": true
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "86962",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T22:59:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T22:59:00.000Z",
+        "time": "2021-03-04T22:59:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T22:59:00.000Z",
+        "time": "2021-03-04T22:59:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178514|12|80|403202186860",
+      "rawId": "1|1178514|12|80|403202186860",
+      "mediumId": "1|1178514|12|80|403202186860",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "86860",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T23:03:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T23:02:00.000Z",
+        "time": "2021-03-04T23:02:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T23:03:00.000Z",
+        "time": "2021-03-04T23:03:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Neugereut, Stuttgart",
+      "scheduledDestination": "Neugereut, Stuttgart",
+      "id": "1|1178313|13|80|403202186973",
+      "rawId": "1|1178313|13|80|403202186973",
+      "mediumId": "1|1178313|13|80|403202186973",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Botnang, Stuttgart"
+        },
+        {
+          "name": "Eltinger Straße, Stuttgart"
+        },
+        {
+          "name": "Millöckerstraße, Stuttgart"
+        },
+        {
+          "name": "Beethovenstraße, Stuttgart"
+        },
+        {
+          "name": "Lindpaintnerstraße, Stuttgart"
+        },
+        {
+          "name": "Herderplatz, Stuttgart"
+        },
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Neugereut, Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "86973",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T23:06:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T23:06:00.000Z",
+        "time": "2021-03-04T23:06:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T23:06:00.000Z",
+        "time": "2021-03-04T23:06:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|12|80|403202186145",
+      "rawId": "1|1178274|12|80|403202186145",
+      "mediumId": "1|1178274|12|80|403202186145",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "86145",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T23:06:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T23:05:00.000Z",
+        "time": "2021-03-04T23:05:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T23:06:00.000Z",
+        "time": "2021-03-04T23:06:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|13|80|403202187383",
+      "rawId": "1|1178487|13|80|403202187383",
+      "mediumId": "1|1178487|13|80|403202187383",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "87383",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T23:12:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T23:12:00.000Z",
+        "time": "2021-03-04T23:12:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T23:12:00.000Z",
+        "time": "2021-03-04T23:12:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|14|80|403202187004",
+      "rawId": "1|1178069|14|80|403202187004",
+      "mediumId": "1|1178069|14|80|403202187004",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "87004",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T23:12:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T23:11:00.000Z",
+        "time": "2021-03-04T23:11:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T23:12:00.000Z",
+        "time": "2021-03-04T23:12:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "scheduledDestination": "Hauptbf (Arnulf-Klett-Platz), Stuttgart",
+      "id": "1|1178310|14|80|403202187580",
+      "rawId": "1|1178310|14|80|403202187580",
+      "mediumId": "1|1178310|14|80|403202187580",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart",
+          "showVia": true
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "87580",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T23:14:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T23:14:00.000Z",
+        "time": "2021-03-04T23:14:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T23:14:00.000Z",
+        "time": "2021-03-04T23:14:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178514|13|80|403202187480",
+      "rawId": "1|1178514|13|80|403202187480",
+      "mediumId": "1|1178514|13|80|403202187480",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Hauptbf (Arnulf-Klett-Platz), Stuttgart"
+        },
+        {
+          "name": "Börsenplatz, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Liederhalle), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "87480",
+        "name": "STB U29",
+        "line": "U29",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T23:18:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T23:17:00.000Z",
+        "time": "2021-03-04T23:17:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T23:18:00.000Z",
+        "time": "2021-03-04T23:18:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Neugereut, Stuttgart",
+      "scheduledDestination": "Neugereut, Stuttgart",
+      "id": "1|1178313|14|80|403202187589",
+      "rawId": "1|1178313|14|80|403202187589",
+      "mediumId": "1|1178313|14|80|403202187589",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Botnang, Stuttgart"
+        },
+        {
+          "name": "Eltinger Straße, Stuttgart"
+        },
+        {
+          "name": "Millöckerstraße, Stuttgart"
+        },
+        {
+          "name": "Beethovenstraße, Stuttgart"
+        },
+        {
+          "name": "Lindpaintnerstraße, Stuttgart"
+        },
+        {
+          "name": "Herderplatz, Stuttgart"
+        },
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Neugereut, Stuttgart"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "87589",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T23:21:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T23:21:00.000Z",
+        "time": "2021-03-04T23:21:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T23:21:00.000Z",
+        "time": "2021-03-04T23:21:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Botnang, Stuttgart",
+      "scheduledDestination": "Botnang, Stuttgart",
+      "id": "1|1178274|13|80|403202186828",
+      "rawId": "1|1178274|13|80|403202186828",
+      "mediumId": "1|1178274|13|80|403202186828",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Neugereut, Stuttgart"
+        },
+        {
+          "name": "Steinhaldenfeld, Stuttgart"
+        },
+        {
+          "name": "Hauptfriedhof, Stuttgart"
+        },
+        {
+          "name": "Obere Ziegelei, Stuttgart"
+        },
+        {
+          "name": "Gnesener Straße, Stuttgart"
+        },
+        {
+          "name": "Kursaal, Stuttgart"
+        },
+        {
+          "name": "Daimlerplatz, Stuttgart"
+        },
+        {
+          "name": "Bad Cannstatt Wilhelmsplatz, Stuttgart"
+        },
+        {
+          "name": "Mercedesstraße, Stuttgart"
+        },
+        {
+          "name": "Mineralbäder, Stuttgart"
+        },
+        {
+          "name": "Metzstraße, Stuttgart"
+        },
+        {
+          "name": "Stöckach, Stuttgart"
+        },
+        {
+          "name": "Neckartor, Stuttgart"
+        },
+        {
+          "name": "Staatsgalerie, Stuttgart"
+        },
+        {
+          "name": "Charlottenplatz, Stuttgart"
+        },
+        {
+          "name": "Rathaus, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang",
+          "showVia": true
+        },
+        {
+          "name": "Herderplatz",
+          "showVia": true
+        },
+        {
+          "name": "Lindpaintnerstraße",
+          "showVia": true
+        },
+        {
+          "name": "Beethovenstraße"
+        },
+        {
+          "name": "Millöckerstraße"
+        },
+        {
+          "name": "Eltinger Straße"
+        },
+        {
+          "name": "Botnang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "86828",
+        "name": "STB U2",
+        "line": "U2",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T23:21:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T23:20:00.000Z",
+        "time": "2021-03-04T23:20:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T23:21:00.000Z",
+        "time": "2021-03-04T23:21:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "369218",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150785,
+          "lat": 48.774831
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Südheimer Platz, Stuttgart",
+      "scheduledDestination": "Südheimer Platz, Stuttgart",
+      "id": "1|1178487|14|80|403202187967",
+      "rawId": "1|1178487|14|80|403202187967",
+      "mediumId": "1|1178487|14|80|403202187967",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Vogelsang, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Schwab-/Bebelstraße",
+          "showVia": true
+        },
+        {
+          "name": "Schloss-/Johannesstraße",
+          "showVia": true
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße)",
+          "showVia": true
+        },
+        {
+          "name": "Stadtmitte"
+        },
+        {
+          "name": "Österreichischer Platz"
+        },
+        {
+          "name": "Marienplatz"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz"
+        },
+        {
+          "name": "Bihlplatz"
+        },
+        {
+          "name": "Südheimer Platz"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "87967",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    },
+    {
+      "initialDeparture": "2021-03-04T23:27:00.000Z",
+      "arrival": {
+        "scheduledTime": "2021-03-04T23:27:00.000Z",
+        "time": "2021-03-04T23:27:00.000Z"
+      },
+      "departure": {
+        "scheduledTime": "2021-03-04T23:27:00.000Z",
+        "time": "2021-03-04T23:27:00.000Z"
+      },
+      "auslastung": false,
+      "currentStation": {
+        "id": "559177",
+        "title": "Arndt-/Spittastraße",
+        "coordinates": {
+          "lng": 9.150767,
+          "lat": 48.774894
+        },
+        "products": [
+          {
+            "name": "STB U2",
+            "line": "U2",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U29",
+            "line": "U29",
+            "type": "STB     "
+          },
+          {
+            "name": "STB U34",
+            "line": "U34",
+            "type": "STB     "
+          }
+        ]
+      },
+      "destination": "Vogelsang, Stuttgart",
+      "scheduledDestination": "Vogelsang, Stuttgart",
+      "id": "1|1178069|15|80|403202187618",
+      "rawId": "1|1178069|15|80|403202187618",
+      "mediumId": "1|1178069|15|80|403202187618",
+      "productClass": "",
+      "messages": {
+        "qos": [],
+        "delay": [],
+        "him": []
+      },
+      "platform": "",
+      "scheduledPlatform": "",
+      "reihung": false,
+      "route": [
+        {
+          "name": "Südheimer Platz, Stuttgart"
+        },
+        {
+          "name": "Bihlplatz, Stuttgart"
+        },
+        {
+          "name": "Erwin-Schoettle-Platz, Stuttgart"
+        },
+        {
+          "name": "Marienplatz, Stuttgart"
+        },
+        {
+          "name": "Österreichischer Platz, Stuttgart"
+        },
+        {
+          "name": "Stadtmitte, Stuttgart"
+        },
+        {
+          "name": "Berliner Platz (Hohe Straße), Stuttgart"
+        },
+        {
+          "name": "Schloss-/Johannesstraße, Stuttgart"
+        },
+        {
+          "name": "Schwab-/Bebelstraße, Stuttgart"
+        },
+        {
+          "name": "Arndt-/Spittastraße"
+        },
+        {
+          "name": "Vogelsang"
+        }
+      ],
+      "train": {
+        "type": "STB",
+        "number": "87618",
+        "name": "STB U34",
+        "line": "U34",
+        "admin": "vvs020",
+        "operator": {
+          "name": "Nahreisezug",
+          "icoX": 1
+        }
+      }
+    }
+  ],
+  "wings": {}
+}

--- a/cypress/fixtures/regional/stationSearchArndtSpittastrasse.json
+++ b/cypress/fixtures/regional/stationSearchArndtSpittastrasse.json
@@ -1,0 +1,252 @@
+[
+  {
+    "id": "000559177",
+    "title": "Arndt-/Spittastraße, Stuttgart",
+    "coordinates": {
+      "lng": 9.150767,
+      "lat": 48.774894
+    },
+    "products": [
+      {
+        "name": "STB U2",
+        "line": "8_vvs020_U2"
+      },
+      {
+        "name": "STB U29",
+        "line": "8_vvs020_U29"
+      },
+      {
+        "name": "STB U34",
+        "line": "8_vvs020_U34"
+      }
+    ]
+  },
+  {
+    "title": "Stuttgart - West, Spittastraße",
+    "coordinates": {
+      "lng": 9.151136,
+      "lat": 48.775281
+    }
+  },
+  {
+    "title": "Stuttgart - West, Arndtstraße",
+    "coordinates": {
+      "lng": 9.151118,
+      "lat": 48.774427
+    }
+  },
+  {
+    "title": "Stuttgart - Ost, Spittlerstraße",
+    "coordinates": {
+      "lng": 9.198644,
+      "lat": 48.787587
+    }
+  },
+  {
+    "title": "Stuttgart - Degerloch, Melittastraße",
+    "coordinates": {
+      "lng": 9.181879,
+      "lat": 48.754722
+    }
+  },
+  {
+    "id": "981238217",
+    "title": "Stuttgart, Melittastraße",
+    "coordinates": {
+      "lng": 9.181879,
+      "lat": 48.754722
+    }
+  },
+  {
+    "id": "991532120",
+    "title": "Stuttgart, Rössle (Arnoldstraße 3) (Gastronomie)",
+    "coordinates": {
+      "lng": 9.229324,
+      "lat": 48.842017
+    }
+  },
+  {
+    "id": "991531742",
+    "title": "Stuttgart, Pasta Baby (Hospitalstraße 19) (Gastron",
+    "coordinates": {
+      "lng": 9.172701,
+      "lat": 48.777294
+    }
+  },
+  {
+    "title": "Stuttgart - Feuerbach, Spitzäckerstraße",
+    "coordinates": {
+      "lng": 9.151351,
+      "lat": 48.808559
+    }
+  },
+  {
+    "title": "Stuttgart - Feuerbach, Spitzwegstraße",
+    "coordinates": {
+      "lng": 9.164089,
+      "lat": 48.801556
+    }
+  },
+  {
+    "title": "Stuttgart - Mitte, Hospitalstraße",
+    "coordinates": {
+      "lng": 9.172719,
+      "lat": 48.777339
+    }
+  },
+  {
+    "title": "Stuttgart - Zazenhausen, Spitalhofstraße",
+    "coordinates": {
+      "lng": 9.199462,
+      "lat": 48.839904
+    }
+  },
+  {
+    "title": "Stuttgart - Zuffenhausen, Spitalstraße",
+    "coordinates": {
+      "lng": 9.178409,
+      "lat": 48.831248
+    }
+  },
+  {
+    "id": "981238399",
+    "title": "Stuttgart, Weiler-Spitz-Straße",
+    "coordinates": {
+      "lng": 9.249442,
+      "lat": 48.749751
+    }
+  },
+  {
+    "title": "Stuttgart - Süd, Cottastraße",
+    "coordinates": {
+      "lng": 9.174723,
+      "lat": 48.766148
+    }
+  },
+  {
+    "title": "Stuttgart - Untertürkheim, Silvrettastraße",
+    "coordinates": {
+      "lng": 9.251446,
+      "lat": 48.781402
+    }
+  },
+  {
+    "title": "Stuttgart - Luginsland, Arnulfstraße",
+    "coordinates": {
+      "lng": 9.262233,
+      "lat": 48.790994
+    }
+  },
+  {
+    "title": "Stuttgart - Mühlhausen, Arnoldstraße",
+    "coordinates": {
+      "lng": 9.223957,
+      "lat": 48.840327
+    }
+  },
+  {
+    "title": "Stuttgart - Zuffenhausen, Spielberger Straße",
+    "coordinates": {
+      "lng": 9.172188,
+      "lat": 48.837648
+    }
+  },
+  {
+    "id": "000560957",
+    "title": "Jurastraße, Stuttgart",
+    "coordinates": {
+      "lng": 9.117156,
+      "lat": 48.728968
+    },
+    "products": [
+      {
+        "name": "STB U3",
+        "line": "8_vvs020_U3"
+      },
+      {
+        "name": "STB U8",
+        "line": "8_vvs020_U8"
+      }
+    ]
+  },
+  {
+    "id": "000559507",
+    "title": "Peregrinastraße, Stuttgart",
+    "coordinates": {
+      "lng": 9.159711,
+      "lat": 48.744205
+    },
+    "products": [
+      {
+        "name": "STB U5",
+        "line": "8_vvs020_U5"
+      },
+      {
+        "name": "STB U6",
+        "line": "8_vvs020_U6"
+      },
+      {
+        "name": "STB U8",
+        "line": "8_vvs020_U8"
+      },
+      {
+        "name": "STB U12",
+        "line": "8_vvs020_U12"
+      }
+    ]
+  },
+  {
+    "id": "000559526",
+    "title": "Rastatter Straße, Stuttgart",
+    "coordinates": {
+      "lng": 9.108203,
+      "lat": 48.810375
+    },
+    "products": [
+      {
+        "name": "STB U6",
+        "line": "8_vvs020_U6"
+      },
+      {
+        "name": "STB U16",
+        "line": "8_vvs020_U16"
+      }
+    ]
+  },
+  {
+    "id": "000559665",
+    "title": "Wilhelm-/Olgastraße, Stuttgart",
+    "coordinates": {
+      "lng": 9.180611,
+      "lat": 48.769528
+    },
+    "products": [
+      {
+        "name": "Bus 43",
+        "line": "5_vvs030_43"
+      }
+    ]
+  },
+  {
+    "id": "000559456",
+    "title": "Mittnachtstraße, Stuttgart",
+    "coordinates": {
+      "lng": 9.190113,
+      "lat": 48.797466
+    },
+    "products": [
+      {
+        "name": "STB U12",
+        "line": "8_vvs020_U12"
+      }
+    ]
+  },
+  {
+    "id": "991531533",
+    "title": "Stuttgart, La Bruschetta (Weberstraße 108) (Gastro",
+    "coordinates": {
+      "lng": 9.184027,
+      "lat": 48.774481
+    }
+  }
+]

--- a/cypress/integration/abfahrten.test.ts
+++ b/cypress/integration/abfahrten.test.ts
@@ -1,65 +1,70 @@
 describe('Abfahrten', () => {
-  beforeEach(() => {
-    cy.mockFrankfurt();
-  });
-  it('open details', () => {
-    cy.visit('/');
-    cy.navigateToStation('Frankfurt (Main) Hbf');
-    cy.findByTestId('abfahrtS35744').click();
-    cy.findByTestId('abfahrtS35744').within(() => {
-      cy.findByTestId('scrollMarker').should('exist');
+  describe('generic', () => {
+    beforeEach(() => {
+      cy.mockFrankfurt();
+      cy.force404();
     });
-    // eslint-disable-next-line jest/valid-expect-in-promise
-    cy.window().then((w) =>
-      cy
-        .get('link[rel="canonical"]')
-        .should('have.attr', 'href', decodeURIComponent(w.location.href)),
-    );
-  });
-  it('opened details should be rememberd on refresh', () => {
-    cy.visit('/');
-    cy.navigateToStation('Frankfurt (Main) Hbf');
-    cy.findByTestId('abfahrtS35744').click();
-    cy.findByTestId('abfahrtS35744').within(() => {
-      cy.findByTestId('scrollMarker').should('exist');
+    it('open details', () => {
+      cy.visit('/');
+      cy.navigateToStation('Frankfurt (Main) Hbf');
+      cy.findByTestId('abfahrtS35744').click();
+      cy.findByTestId('abfahrtS35744').within(() => {
+        cy.findByTestId('scrollMarker').should('exist');
+      });
+      // eslint-disable-next-line jest/valid-expect-in-promise
+      cy.window().then((w) =>
+        cy
+          .get('link[rel="canonical"]')
+          .should('have.attr', 'href', decodeURIComponent(w.location.href)),
+      );
     });
-    cy.visit('/');
-    cy.navigateToStation('Frankfurt (Main) Hbf');
-    cy.findByTestId('abfahrtS35744').within(() => {
-      cy.findByTestId('scrollMarker').should('exist');
+    it('opened details should be rememberd on refresh', () => {
+      cy.visit('/');
+      cy.navigateToStation('Frankfurt (Main) Hbf');
+      cy.findByTestId('abfahrtS35744').click();
+      cy.findByTestId('abfahrtS35744').within(() => {
+        cy.findByTestId('scrollMarker').should('exist');
+      });
+      cy.visit('/');
+      cy.navigateToStation('Frankfurt (Main) Hbf');
+      cy.findByTestId('abfahrtS35744').within(() => {
+        cy.findByTestId('scrollMarker').should('exist');
+      });
     });
-  });
-  it('details should be closed if you open another', () => {
-    cy.visit('/');
-    cy.navigateToStation('Frankfurt (Main) Hbf');
-    cy.findByTestId('abfahrtS35744').click();
-    cy.findByTestId('abfahrtS35744').within(() => {
-      cy.findByTestId('scrollMarker').should('exist');
-    });
+    it('details should be closed if you open another', () => {
+      cy.visit('/');
+      cy.navigateToStation('Frankfurt (Main) Hbf');
+      cy.findByTestId('abfahrtS35744').click();
+      cy.findByTestId('abfahrtS35744').within(() => {
+        cy.findByTestId('scrollMarker').should('exist');
+      });
 
-    cy.findByTestId('abfahrtRE4568').click();
-    cy.findByTestId('abfahrtRE4568').within(() => {
-      cy.findByTestId('scrollMarker').should('exist');
-    });
-    cy.findByTestId('abfahrtS35744').within(() => {
-      cy.findByTestId('scrollMarker').should('not.exist');
+      cy.findByTestId('abfahrtRE4568').click();
+      cy.findByTestId('abfahrtRE4568').within(() => {
+        cy.findByTestId('scrollMarker').should('exist');
+      });
+      cy.findByTestId('abfahrtS35744').within(() => {
+        cy.findByTestId('scrollMarker').should('not.exist');
+      });
     });
   });
   it('going back & showing different station should reload', () => {
+    cy.mockFrankfurt({ delay: 2000 });
+    cy.mockHamburg({ delay: 2000 });
+    cy.force404();
     cy.visit('/');
-    cy.mockFrankfurt();
     cy.navigateToStation('Frankfurt (Main) Hbf');
     cy.findByTestId('loading').should('exist');
     cy.findByTestId('lookahead').should('exist');
     cy.go('back');
-    cy.mockHamburg();
     cy.navigateToStation('Hamburg Hbf');
     cy.findByTestId('loading').should('exist');
     cy.findByTestId('lookahead').should('exist');
   });
   it('Zugausfall not strike through', () => {
-    cy.visit('/');
     cy.mockHamburg();
+    cy.force404();
+    cy.visit('/');
     cy.navigateToStation('Hamburg Hbf');
     cy.findByTestId('abfahrtRB81616').within(() => {
       cy.findByTestId('zugausfall').should(

--- a/cypress/integration/abfahrtenSettings.test.ts
+++ b/cypress/integration/abfahrtenSettings.test.ts
@@ -7,6 +7,7 @@ describe('Abfahrten Settings', () => {
     });
 
     it('Show Zugnummer & Linie', () => {
+      cy.force404();
       cy.findByTestId('abfahrtS35744').within(() => {
         cy.findByTestId('abfahrtStart').should('have.text', 'S 7');
       });
@@ -19,14 +20,10 @@ describe('Abfahrten Settings', () => {
     });
 
     it('Show fahrzeuggruppe', () => {
-      cy.route(
-        '/api/hafas/v2/auslastung/8000105/Interlaken Ost/371/2019-08-07T12:50:00.000Z',
-        { first: 1, second: 1 },
-      );
-      cy.route(
-        '/api/reihung/v2/wagen/371/2019-08-07T12:50:00.000Z',
-        'fixture:sequence/genericICE1.json',
-      );
+      cy.intercept('/api/reihung/v2/wagen/371/2019-08-07T12:50:00.000Z', {
+        fixture: 'sequence/genericICE1',
+      });
+      cy.force404();
       cy.findByTestId('abfahrtICE371').click();
       cy.openSettings();
       cy.findByTestId('fahrzeugGruppeConfig').click();
@@ -45,6 +42,7 @@ describe('Abfahrten Settings', () => {
   });
 
   it('set lookbehind', () => {
+    cy.force404();
     cy.visit('/');
     cy.openSettings();
     cy.findByTestId('lookbehind').within(() => {

--- a/cypress/integration/details.test.ts
+++ b/cypress/integration/details.test.ts
@@ -1,18 +1,19 @@
 describe('Details', () => {
   it('Can Render (with error)', () => {
-    cy.route({
-      url: '/api/hafas/v2/details/ICE70',
-      status: 404,
+    cy.intercept('/api/hafas/v2/details/ICE70', {
+      statusCode: 404,
       response: {},
     });
+    cy.force404();
     cy.visit('/details/ICE70');
     cy.findByTestId('error').should('exist');
   });
 
   it('can render & header height correct', () => {
-    cy.route('/api/hafas/v2/details/S30665', 'fixture:details/S6.json').as(
-      'details',
-    );
+    cy.intercept('/api/hafas/v2/details/S30665', {
+      fixture: 'details/S6',
+    }).as('details');
+    cy.force404();
     cy.visit('/details/S30665');
     cy.wait('@details');
     cy.findByTestId('header').should('have.css', 'height', '54px');

--- a/cypress/integration/filter.test.ts
+++ b/cypress/integration/filter.test.ts
@@ -5,6 +5,7 @@ describe('Filter', () => {
   }
   beforeEach(() => {
     cy.mockFrankfurt();
+    cy.force404();
   });
   it('Type Filter Temporary', () => {
     cy.visit('/');

--- a/cypress/integration/homepage.test.ts
+++ b/cypress/integration/homepage.test.ts
@@ -35,15 +35,17 @@ describe('Homepage', () => {
   });
 
   it('Shows error on mainPage', () => {
-    cy.route({
-      url: '/api/iris/v2/abfahrten/8098105?lookahead=150&lookbehind=0',
-      status: 500,
-      delay: 200,
-      response: {},
-    }).route(
-      '/api/station/v1/search/Frankfurt (Main) Hbf?type=default',
-      'fixture:stationSearchFrankfurtHbf.json',
+    cy.intercept('/api/iris/v2/abfahrten/8098105', {
+      statusCode: 500,
+      delayMs: 2000,
+      body: {},
+    }).intercept(
+      `/api/station/v1/search/${encodeURIComponent('Frankfurt (Main) Hbf')}`,
+      {
+        fixture: 'stationSearchFrankfurtHbf',
+      },
     );
+    cy.force404();
     cy.visit('/');
     cy.navigateToStation('Frankfurt (Main) Hbf');
     cy.findByTestId('loading').should('exist');

--- a/cypress/integration/map.test.ts
+++ b/cypress/integration/map.test.ts
@@ -1,10 +1,15 @@
 describe('Map', () => {
   it('opens oebb by default', () => {
-    cy.route({
-      url: '/api/hafas/v1/journeyGeoPos?profile=oebb',
-      method: 'POST',
-      response: 'fixture:journeyGeoPosOebbSingle.json',
-    }).as('geoPos');
+    cy.intercept(
+      {
+        url: '/api/hafas/v1/journeyGeoPos?profile=oebb',
+        method: 'POST',
+      },
+      {
+        fixture: 'journeyGeoPosOebbSingle',
+      },
+    ).as('geoPos');
+    cy.force404();
     cy.visit('/map?noTiles=1');
     cy.wait('@geoPos');
   });
@@ -19,11 +24,16 @@ describe('Map', () => {
     };
 
     it('profile', () => {
-      cy.route({
-        url: '/api/hafas/v1/journeyGeoPos?profile=db',
-        method: 'POST',
-        response: 'fixture:journeyGeoPosOebbSingle.json',
-      }).as('geoPos');
+      cy.intercept(
+        {
+          url: '/api/hafas/v1/journeyGeoPos?profile=db',
+          method: 'POST',
+        },
+        {
+          fixture: 'journeyGeoPosOebbSingle',
+        },
+      ).as('geoPos');
+      cy.force404();
       cy.visit('/map?profile=db&noTiles=1');
       cy.wait('@geoPos');
     });

--- a/cypress/integration/regional.test.ts
+++ b/cypress/integration/regional.test.ts
@@ -17,6 +17,18 @@ describe('Regional', () => {
       '/api/hafas/v2/details/STR 1761?station=723870&date=2020-05-02T17:54:00.000Z',
       'fixture:regional/detailsStr1761.json',
     );
+    cy.route(
+      '/api/hafas/v1/station/Arndt-/Spittastraße, Stuttgart?profile=db&type=S',
+      'fixture:regional/stationSearchArndtSpittastrasse.json',
+    );
+    cy.route(
+      '/api/hafas/v1/station/Arndt-/Spittastraße, Stuttgart?type=S',
+      'fixture:regional/stationSearchArndtSpittastrasse.json',
+    );
+    cy.route(
+      '/api/hafas/experimental/irisCompatibleAbfahrten/000559177?lookahead=150&lookbehind=0',
+      'fixture:regional/departureArndtSpittastrasse.json',
+    );
     cy.visit('/');
     cy.findByTestId('navToggle').click();
     cy.findByTestId('regional').click();
@@ -30,5 +42,10 @@ describe('Regional', () => {
         '/regional/Karlsruhe%20Bahnhofsvorplatz',
       );
     });
+    cy.visit('/');
+    cy.findByTestId('navToggle').click();
+    cy.findByTestId('regional').click();
+    cy.navigateToStation('Arndt-/Spittastraße, Stuttgart');
+    cy.findByTestId('abfahrtSTB77629');
   });
 });

--- a/cypress/integration/regional.test.ts
+++ b/cypress/integration/regional.test.ts
@@ -1,23 +1,26 @@
 describe('Regional', () => {
   it('can navigate to Details Page', () => {
-    cy.server();
-    cy.route(
-      '/api/hafas/v1/station/Poststraße, Karlsruhe?profile=db&type=S',
-      'fixture:regional/stationSearchPoststrasse',
+    cy.intercept(
+      `/api/hafas/v1/station/${encodeURIComponent('Poststraße, Karlsruhe')}`,
+      {
+        fixture: 'regional/stationSearchPoststrasse',
+      },
     );
-    cy.route(
-      '/api/hafas/v1/station/Poststraße, Karlsruhe?type=S',
-      'fixture:regional/stationSearchPoststrasse',
-    );
-    cy.route(
+    cy.intercept(
       '/api/hafas/experimental/irisCompatibleAbfahrten/000723869?lookahead=150&lookbehind=0',
-      'fixture:regional/departurePostStrasse.json',
+      { fixture: 'regional/departurePostStrasse' },
     );
-    cy.route(
-      '/api/hafas/v2/details/STR 1761?station=723870&date=2020-05-02T17:54:00.000Z',
-      'fixture:regional/detailsStr1761.json',
+    cy.intercept(
+      {
+        url: `/api/hafas/v2/details/${encodeURIComponent('STR 1761')}`,
+        query: {
+          station: '723870',
+          date: '2020-05-02T17:54:00.000Z',
+        },
+      },
+      { fixture: 'regional/detailsStr1761' },
     );
-
+    cy.force404();
     cy.visit('/');
     cy.findByTestId('navToggle').click();
     cy.findByTestId('regional').click();
@@ -37,12 +40,13 @@ describe('Regional', () => {
     cy.intercept(
       '/api/hafas/v1/station/' +
         encodeURIComponent('Arndt-/Spittastraße, Stuttgart'),
-      { fixture: 'regional/stationSearchArndtSpittastrasse.json' },
+      { fixture: 'regional/stationSearchArndtSpittastrasse' },
     );
     cy.intercept(
       '/api/hafas/experimental/irisCompatibleAbfahrten/000559177?lookahead=150&lookbehind=0',
-      { fixture: 'regional/departureArndtSpittastrasse.json' },
+      { fixture: 'regional/departureArndtSpittastrasse' },
     );
+    cy.force404();
     cy.visit('/');
     cy.findByTestId('navToggle').click();
     cy.findByTestId('regional').click();

--- a/cypress/integration/regional.test.ts
+++ b/cypress/integration/regional.test.ts
@@ -17,18 +17,7 @@ describe('Regional', () => {
       '/api/hafas/v2/details/STR 1761?station=723870&date=2020-05-02T17:54:00.000Z',
       'fixture:regional/detailsStr1761.json',
     );
-    cy.route(
-      '/api/hafas/v1/station/Arndt-/Spittastraße, Stuttgart?profile=db&type=S',
-      'fixture:regional/stationSearchArndtSpittastrasse.json',
-    );
-    cy.route(
-      '/api/hafas/v1/station/Arndt-/Spittastraße, Stuttgart?type=S',
-      'fixture:regional/stationSearchArndtSpittastrasse.json',
-    );
-    cy.route(
-      '/api/hafas/experimental/irisCompatibleAbfahrten/000559177?lookahead=150&lookbehind=0',
-      'fixture:regional/departureArndtSpittastrasse.json',
-    );
+
     cy.visit('/');
     cy.findByTestId('navToggle').click();
     cy.findByTestId('regional').click();
@@ -42,6 +31,18 @@ describe('Regional', () => {
         '/regional/Karlsruhe%20Bahnhofsvorplatz',
       );
     });
+  });
+
+  it('can handle slashes', () => {
+    cy.intercept(
+      '/api/hafas/v1/station/' +
+        encodeURIComponent('Arndt-/Spittastraße, Stuttgart'),
+      { fixture: 'regional/stationSearchArndtSpittastrasse.json' },
+    );
+    cy.intercept(
+      '/api/hafas/experimental/irisCompatibleAbfahrten/000559177?lookahead=150&lookbehind=0',
+      { fixture: 'regional/departureArndtSpittastrasse.json' },
+    );
     cy.visit('/');
     cy.findByTestId('navToggle').click();
     cy.findByTestId('regional').click();

--- a/cypress/integration/reihung.test.ts
+++ b/cypress/integration/reihung.test.ts
@@ -3,15 +3,11 @@ describe('Reihung', () => {
     beforeEach(() => {
       cy.mockFrankfurt();
       cy.visit('/');
+      cy.intercept('/api/reihung/v2/wagen/371/2019-08-07T12:50:00.000Z', {
+        fixture: 'sequence/genericICE1',
+      });
+      cy.force404();
       cy.navigateToStation('Frankfurt (Main) Hbf');
-      cy.route(
-        '/api/hafas/v2/auslastung/8000105/Interlaken Ost/371/2019-08-07T12:50:00.000Z',
-        { first: 1, second: 1 },
-      );
-      cy.route(
-        '/api/reihung/v2/wagen/371/2019-08-07T12:50:00.000Z',
-        'fixture:sequence/genericICE1.json',
-      );
       cy.findByTestId('abfahrtICE371').click();
     });
 
@@ -45,15 +41,11 @@ describe('Reihung', () => {
       cy.mockHannover();
       cy.visit('/');
       cy.navigateToStation('Hannover Hbf');
-      cy.route(
-        '/api/reihung/v2/wagen/537/2020-02-22T11:26:00.000Z',
-        'fixture:sequence/537Wing.json',
-      ).as('537');
-      cy.route({
-        method: 'GET',
-        url: '/api/reihung/v2/wagen/587/2020-02-22T11:26:00.000Z',
-        status: 404,
-        response: '',
+      cy.intercept('/api/reihung/v2/wagen/537/2020-02-22T11:26:00.000Z', {
+        fixture: 'sequence/537Wing',
+      }).as('537');
+      cy.intercept('/api/reihung/v2/wagen/587/2020-02-22T11:26:00.000Z', {
+        statusCode: 404,
       }).as('587');
     });
     it('only loads reihung of selected train if available', () => {

--- a/cypress/integration/routing/routing.test.ts
+++ b/cypress/integration/routing/routing.test.ts
@@ -1,29 +1,22 @@
 describe('Routing', () => {
   beforeEach(() => {
-    cy.route(
-      '/api/hafas/v1/station/Frankfurt Hbf?profile=db&type=S',
-      'fixture:stationSearchFrankfurtHbf.json',
+    cy.intercept(
+      `/api/hafas/v1/station/${encodeURIComponent('Frankfurt Hbf')}`,
+      { fixture: 'stationSearchFrankfurtHbf' },
     );
-    cy.route(
-      '/api/hafas/v1/station/Hamburg Hbf?profile=db&type=S',
-      'fixture:stationSearchHamburgHbf.json',
-    );
+    cy.intercept(`/api/hafas/v1/station/${encodeURIComponent('Hamburg Hbf')}`, {
+      fixture: 'stationSearchHamburgHbf',
+    });
   });
   describe('Favorites', () => {
     it('Initially no favs', () => {
+      cy.force404();
       cy.visit('/routing');
       cy.findByTestId('RouteFavEntry').should('not.exist');
     });
 
     it('Can save fav, is saved on reload', () => {
-      cy.route(
-        '/api/hafas/v1/station/Frankfurt Hbf?profile=db&type=S',
-        'fixture:stationSearchFrankfurtHbf.json',
-      );
-      cy.route(
-        '/api/hafas/v1/station/Hamburg Hbf?profile=db&type=S',
-        'fixture:stationSearchHamburgHbf.json',
-      );
+      cy.force404();
       cy.visit('/routing');
       cy.navigateToStation('Frankfurt Hbf', {
         findPrefix: 'routingStartSearch',
@@ -35,69 +28,6 @@ describe('Routing', () => {
       cy.findByTestId('RouteFavEntry-80981058002549db').should('exist');
       cy.visit('/routing');
       cy.findByTestId('RouteFavEntry-80981058002549db').should('exist');
-    });
-
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('Changes profile only for Fav', () => {
-      cy.route(
-        '/api/hafas/v1/station/8098105?profile=db&type=S',
-        'fixture:stationSearchFrankfurtHbf.json',
-      );
-      cy.route(
-        '/api/hafas/v1/station/8002549?profile=db&type=S',
-        'fixture:stationSearchHamburgHbf.json',
-      );
-      cy.route({
-        method: 'POST',
-        url: '/api/hafas/v2/tripSearch?profile=db',
-        response: 'fixture:routing/FFMToHH.json',
-      }).as('RouteSearchDB');
-
-      // Set up Favorite
-      cy.visit('/routing');
-      cy.navigateToStation('Frankfurt Hbf', {
-        findPrefix: 'routingStartSearch',
-      });
-      cy.navigateToStation('Hamburg Hbf', {
-        findPrefix: 'routingDestinationSearch',
-      });
-      cy.findByTestId('routingFavButton').click();
-      cy.setCookie('hafasProfile', 'oebb');
-      // Call Favorite
-      cy.visit('/routing');
-      cy.findByTestId('routingSettingsPanel').click();
-      cy.findByTestId('routingHafasProfile').should('have.value', 'oebb');
-      cy.findByTestId('RouteFavEntry-80981058002549db').click();
-      cy.wait('@RouteSearchDB');
-      cy.findByTestId('Route-C-0').should('exist');
-      // Use Fetch Earlier to check if currently correct profile is used
-      cy.findByTestId('fetchCtxEarly').click();
-      cy.wait('@RouteSearchDB');
-      cy.findByTestId('fetchCtxEarly').should('exist');
-      // Swap start & destination
-      cy.findByTestId('swapStations').click();
-      cy.findByTestId('routingStartSearch')
-        .findByTestId('stationSearchInput')
-        .should('have.value', 'Hamburg Hbf');
-      cy.findByTestId('routingDestinationSearch')
-        .findByTestId('stationSearchInput')
-        .should('have.value', 'Frankfurt (Main) Hbf');
-      // Search with saved Profile -> OEBB
-      cy.route(
-        '/api/hafas/v1/station/8098105?profile=oebb',
-        'fixture:stationSearchFrankfurtHbf.json',
-      );
-      cy.route(
-        '/api/hafas/v1/station/8002549?profile=oebb',
-        'fixture:stationSearchHamburgHbf.json',
-      );
-      cy.route({
-        method: 'POST',
-        url: '/api/hafas/v2/tripSearch?profile=oebb',
-        response: 'fixture:routing/HHToFFM.json',
-      });
-      cy.findByTestId('search').click();
-      cy.findByTestId('Route-C-0-OEBB').should('exist');
     });
   });
 });

--- a/cypress/integration/routing/settings.test.ts
+++ b/cypress/integration/routing/settings.test.ts
@@ -2,6 +2,7 @@ describe('Routing Settings', () => {
   describe('normal', () => {
     beforeEach(() => {
       cy.visit('/routing');
+      cy.force404();
     });
     it('can change settings', () => {
       cy.findByTestId('routingSettingsPanel')

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -16,7 +16,6 @@ declare global {
       navigateToStation(
         value: string,
         options?: {
-          isStubbed?: boolean;
           findPrefix?: string;
         },
       ): void;
@@ -25,6 +24,7 @@ declare global {
       mockHamburg(options?: MockOptions): void;
       mockHannover(options?: MockOptions): void;
       openSettings(): void;
+      force404(): void;
     }
   }
 }

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -3,12 +3,3 @@ import './commands';
 Cypress.Server.defaults({
   force404: true,
 });
-beforeEach(() => {
-  cy.server();
-});
-
-Cypress.on('window:before:load', (win) => {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  delete win.fetch;
-});

--- a/packages/client/Common/service/stationSearch.ts
+++ b/packages/client/Common/service/stationSearch.ts
@@ -27,14 +27,20 @@ export async function getHafasStationFromAPI(
   stationString?: string,
 ): Promise<Station[]> {
   try {
-    return (
-      await Axios.get<Station[]>(`/api/hafas/v1/station/${stationString}`, {
-        params: {
-          profile,
-          type: 'S',
-        },
-      })
-    ).data;
+    if (stationString) {
+      return (
+        await Axios.get<Station[]>(
+          `/api/hafas/v1/station/${encodeURIComponent(stationString)}`,
+          {
+            params: {
+              profile,
+              type: 'S',
+            },
+          },
+        )
+      ).data;
+    }
+    return [];
   } catch {
     return [];
   }


### PR DESCRIPTION
Searching for a (HAFAS) station with a slash (example "Arndt-/Spittastraße, Stuttgart") results in

Nahverkehr Abfahrten <BETA>
Die Abfahrt existiert nicht
Arndt-/Spittastraße, Stuttgart

as the slash isn't encoded: `https://marudor.de/api/hafas/v1/station/Arndt-/Spittastra%C3%9Fe,%20Stuttgart?type=S`